### PR TITLE
supports build with platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ lib_extra_dirs = ${workspacedir} ;this points to the root directory where the ar
 build_flags = -D USE_NIMBLE
 #https://github.com/espressif/esp-idf/tree/master/components/partition_table
 #https://github.com/espressif/arduino-esp32/tree/master/tools/partitions
-board_build.partitions = huge_app.csv
+board_build.partitions = min_spiffs.csv
 
 lib_deps =
     adafruit/Adafruit BusIO

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,48 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = nodemcu-32s
+src_dir = .
+data_dir = data
+
+[env]
+lib_extra_dirs = ${workspacedir} ;this points to the root directory where the arduino library is located
+build_flags = -D USE_NIMBLE
+#https://github.com/espressif/esp-idf/tree/master/components/partition_table
+#https://github.com/espressif/arduino-esp32/tree/master/tools/partitions
+board_build.partitions = huge_app.csv
+
+lib_deps =
+    adafruit/Adafruit BusIO
+    adafruit/Adafruit SSD1306@2.5.3
+    adafruit/Adafruit GFX Library@1.10.14
+    bblanchon/ArduinoJson@6.19.4
+    thebigpotatoe/Effortless-SPIFFS@2.3.0
+    t-vk/ESP32 BLE Keyboard@0.3.0
+    h2zero/NimBLE-Arduino@1.3.1
+    mickey9801/ButtonFever@1.0.0
+
+[env:nodemcu-32s]
+platform = espressif32
+board = nodemcu-32s
+framework = arduino
+; COM1 or COM3
+upload_port = COM[5]
+;upload_speed
+
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
+
+; COM1 or COM3
+upload_port = COM[5]
+;upload_speed


### PR DESCRIPTION
I've created a configuration file for platformio.

Within platformio you can build a project without messing with libraries and versions.

The configuration file has been prepared with compatibility with sloeber.

An user just need to adjust the com port for upload